### PR TITLE
Use env var for blob trigger container path

### DIFF
--- a/az-func-audio/function_app.py
+++ b/az-func-audio/function_app.py
@@ -18,7 +18,7 @@ app = func.FunctionApp()
 
 @app.blob_trigger(
     arg_name="myblob",
-    path="recordingcontainer/{name}",
+    path="%AZURE_STORAGE_RECORDINGS_CONTAINER%/{name}",
     connection="audio",
 )
 def blob_trigger(myblob: func.InputStream):


### PR DESCRIPTION
Updated Path to use the "AZURE_STORAGE_RECORDINGS_CONTAINER" environment variable, making deployment easier.